### PR TITLE
Fixed checkpoints and bridges having bad node paths to tilemap.

### DIFF
--- a/scripts/activateables/bridge.gd
+++ b/scripts/activateables/bridge.gd
@@ -6,7 +6,7 @@ extends "res://scripts/activatable.gd"
 @export var end_tile: Vector2
 
 @export var bridge_tile: Vector2 = Vector2(1, 5)
-@onready var tile_map = $TileMap
+@onready var tile_map = $"../../TileMap"
 
 func activate():
 	for i in range(end_tile.x - start_tile.x):

--- a/scripts/checkpoint.gd
+++ b/scripts/checkpoint.gd
@@ -2,7 +2,7 @@ class_name Checkpoint extends Area2D
 
 @export var id = 1
 @export var checked_atlas = Vector2(3, 1) 
-@onready var tilemap = $"../TileMap"
+@onready var tilemap = $"../../TileMap"
 
 var checked = false
 


### PR DESCRIPTION
The node paths assigned to bridges' and checkpoints' tilemap references were incorrect, preventing players from passing the first guitar puzzle.